### PR TITLE
Reinstated version number because VS2015 uses it.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "react",
+  "version": "15.0.1",
   "main": ["react.js", "react-dom.js"],
   "ignore": []
 }


### PR DESCRIPTION
Visual Studio 2015's Bower Package Manager uses the version number, therefor it should be reinstated.

fix #17
